### PR TITLE
chore: release v0.0.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["orso", "orso-macros"]
 resolver = "2"
 
 [workspace.package]
-version = "0.0.1"
+version = "0.0.2"
 edition = "2021"
 authors = ["https://github.com/tia-lab"]
 license = "MIT OR Apache-2.0"

--- a/orso-macros/CHANGELOG.md
+++ b/orso-macros/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]

--- a/orso/CHANGELOG.md
+++ b/orso/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.2](https://github.com/tia-lab/orso/compare/orso-v0.0.1...orso-v0.0.2) - 2025-09-15
+
+### Other
+
+- [16] chore: remove outdated dependency example from README.md

--- a/orso/Cargo.toml
+++ b/orso/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["database"]
 readme = "../README.md"
 
 [dependencies]
-orso-macros = { path = "../orso-macros", version = "0.0.1" }
+orso-macros = { path = "../orso-macros", version = "0.0.2" }
 libsql = "0.9.14"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"


### PR DESCRIPTION



## 🤖 New release

* `orso-macros`: 0.0.1 -> 0.0.2
* `orso`: 0.0.1 -> 0.0.2

<details><summary><i><b>Changelog</b></i></summary><p>


## `orso`

<blockquote>

## [0.0.2](https://github.com/tia-lab/orso/compare/orso-v0.0.1...orso-v0.0.2) - 2025-09-15

### Other

- [16] chore: remove outdated dependency example from README.md
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).