### PR TITLE
Fix codec and enhance timestamp utility functions

### DIFF
--- a/orso-macros/src/lib.rs
+++ b/orso-macros/src/lib.rs
@@ -1234,32 +1234,32 @@ pub fn derive_orso(input: TokenStream) -> TokenStream {
 
 
             // Utility methods
-            fn row_to_map(row: &libsql::Row) -> orso::Result<std::collections::HashMap<String, orso::Value>> {
+            fn row_to_map(row: &orso::libsql::Row) -> orso::Result<std::collections::HashMap<String, orso::Value>> {
                 let mut map = std::collections::HashMap::new();
                 for i in 0..row.column_count() {
                     if let Some(column_name) = row.column_name(i) {
-                        let value = row.get_value(i).unwrap_or(libsql::Value::Null);
+                        let value = row.get_value(i).unwrap_or(orso::libsql::Value::Null);
                         map.insert(column_name.to_string(), Self::libsql_value_to_value(&value));
                     }
                 }
                 Ok(map)
             }
 
-            fn value_to_libsql_value(value: &orso::Value) -> libsql::Value {
+            fn value_to_libsql_value(value: &orso::Value) -> orso::libsql::Value {
                 match value {
-                    orso::Value::Null => libsql::Value::Null,
-                    orso::Value::Integer(i) => libsql::Value::Integer(*i),
-                    orso::Value::Real(f) => libsql::Value::Real(*f),
-                    orso::Value::Text(s) => libsql::Value::Text(s.clone()),
-                    orso::Value::Blob(b) => libsql::Value::Blob(b.clone()),
-                    orso::Value::Boolean(b) => libsql::Value::Integer(if *b { 1 } else { 0 }),
+                    orso::Value::Null => orso::libsql::Value::Null,
+                    orso::Value::Integer(i) => orso::libsql::Value::Integer(*i),
+                    orso::Value::Real(f) => orso::libsql::Value::Real(*f),
+                    orso::Value::Text(s) => orso::libsql::Value::Text(s.clone()),
+                    orso::Value::Blob(b) => orso::libsql::Value::Blob(b.clone()),
+                    orso::Value::Boolean(b) => orso::libsql::Value::Integer(if *b { 1 } else { 0 }),
                 }
             }
 
-            fn libsql_value_to_value(value: &libsql::Value) -> orso::Value {
+            fn libsql_value_to_value(value: &orso::libsql::Value) -> orso::Value {
                 match value {
-                    libsql::Value::Null => orso::Value::Null,
-                    libsql::Value::Integer(i) => {
+                    orso::libsql::Value::Null => orso::Value::Null,
+                    orso::libsql::Value::Integer(i) => {
                         // SQLite stores booleans as integers 0/1
                         // Check if this might be a boolean value
                         if *i == 0 || *i == 1 {
@@ -1270,9 +1270,9 @@ pub fn derive_orso(input: TokenStream) -> TokenStream {
                             orso::Value::Integer(*i)
                         }
                     },
-                    libsql::Value::Real(f) => orso::Value::Real(*f),
-                    libsql::Value::Text(s) => orso::Value::Text(s.clone()),
-                    libsql::Value::Blob(b) => orso::Value::Blob(b.clone()),
+                    orso::libsql::Value::Real(f) => orso::Value::Real(*f),
+                    orso::libsql::Value::Text(s) => orso::Value::Text(s.clone()),
+                    orso::libsql::Value::Blob(b) => orso::Value::Blob(b.clone()),
                 }
             }
         }
@@ -1425,7 +1425,7 @@ fn map_field_type(rust_type: &syn::Type, _field: &syn::Field) -> proc_macro2::To
     if let syn::Type::Path(type_path) = rust_type {
         if let Some(segment) = type_path.path.segments.last() {
             let type_name = segment.ident.to_string();
-            
+
             // Handle Vec<T> types by checking the inner type
             if type_name == "Vec" {
                 if let syn::PathArguments::AngleBracketed(args) = &segment.arguments {
@@ -1435,7 +1435,7 @@ fn map_field_type(rust_type: &syn::Type, _field: &syn::Field) -> proc_macro2::To
                     }
                 }
             }
-            
+
             return match type_name.as_str() {
                 "String" => quote! { orso::FieldType::Text },
                 "i64" => quote! { orso::FieldType::BigInt },

--- a/orso/Cargo.toml
+++ b/orso/Cargo.toml
@@ -26,10 +26,9 @@ tracing = "0.1"
 anyhow = "1.0"
 uuid = { version = "1.0", features = ["v4", "serde"] }
 async-trait = "0.1"
-lz4_flex = { version = "0.11", features = ["std"] }
-integer-encoding = "3"
-rayon = "1.7"
 rand = "0.8"
+cydec = { git = "https://github.com/tia-lab/cydec" }
+
 
 [dev-dependencies]
 tracing-test = "0.2"

--- a/orso/src/lib.rs
+++ b/orso/src/lib.rs
@@ -1,8 +1,6 @@
 pub mod database;
 pub mod error;
 pub mod filters;
-pub mod floating_codec;
-pub mod integer_codec;
 pub mod macros;
 pub mod migrations;
 pub mod operations;
@@ -19,12 +17,17 @@ mod test;
 #[cfg(feature = "sqlite")]
 mod test_sqlite;
 
+// Re-export libsql and rusqlite for macro use
+#[cfg(feature = "libsql")]
+pub use libsql;
+#[cfg(feature = "sqlite")]
+pub use rusqlite;
+
 pub use chrono;
+pub use cydec::{FloatingCodec, IntegerCodec};
 pub use database::*;
 pub use error::{Error, Result};
 pub use filters::{Filter, FilterOperations, FilterOperator, FilterValue, SearchFilter, Sort};
-pub use floating_codec::FloatingCodec;
-pub use integer_codec::IntegerCodec;
 pub use migrations::{MigrationEntry, MigrationResult, MigrationTrait, Migrations};
 pub use orso_macros::{orso_column, orso_table, Orso};
 pub use pagination::{CursorPaginatedResult, CursorPagination, PaginatedResult, Pagination};

--- a/orso/src/test.rs
+++ b/orso/src/test.rs
@@ -1002,9 +1002,7 @@ Test completed successfully!"
 
     #[tokio::test]
     async fn batch_compression_test() -> Result<(), Box<dyn std::error::Error>> {
-        use orso::{
-            migration, Database, DatabaseConfig, FloatingCodec, IntegerCodec, Migrations, Orso,
-        };
+        use orso::{migration, Database, DatabaseConfig, Migrations, Orso};
         use serde::{Deserialize, Serialize};
 
         #[derive(Orso, Serialize, Deserialize, Clone, Debug, Default)]

--- a/orso/src/utils.rs
+++ b/orso/src/utils.rs
@@ -1,4 +1,5 @@
 //! Utility functions for ORSO
+
 use chrono::{DateTime, Utc};
 use uuid::Uuid;
 
@@ -15,8 +16,32 @@ impl Utils {
         Some(Utc::now())
     }
 
+    pub fn create_timestamp(timestamp: DateTime<Utc>) -> String {
+        timestamp.to_rfc3339()
+    }
+
     pub fn parse_timestamp(timestamp: &str) -> Result<DateTime<Utc>, chrono::ParseError> {
         DateTime::parse_from_rfc3339(timestamp).map(|dt| dt.with_timezone(&Utc))
+    }
+
+    /// Convert DateTime to Unix timestamp (seconds since epoch)
+    pub fn datetime_to_unix_timestamp(dt: &DateTime<Utc>) -> i64 {
+        dt.timestamp()
+    }
+
+    /// Convert Unix timestamp (seconds since epoch) to DateTime
+    pub fn unix_timestamp_to_datetime(timestamp: i64) -> DateTime<Utc> {
+        DateTime::from_timestamp(timestamp, 0).unwrap_or_else(|| Utc::now())
+    }
+
+    /// Convert DateTime to Unix timestamp with milliseconds
+    pub fn datetime_to_unix_timestamp_millis(dt: &DateTime<Utc>) -> i64 {
+        dt.timestamp_millis()
+    }
+
+    /// Convert Unix timestamp with milliseconds to DateTime
+    pub fn unix_timestamp_millis_to_datetime(timestamp: i64) -> DateTime<Utc> {
+        DateTime::from_timestamp_millis(timestamp).unwrap_or_else(|| Utc::now())
     }
 }
 impl Utils {


### PR DESCRIPTION
Correct codec references and add new utility functions for timestamp conversion, including methods for Unix timestamps in seconds and milliseconds.